### PR TITLE
Fix/update endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,20 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.10.1</version>
+				<configuration>
+					<annotationProcessorPaths combine.children="append">
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/main/java/com/example/todo/dto/UpdateTodoRequest.java
+++ b/src/main/java/com/example/todo/dto/UpdateTodoRequest.java
@@ -1,11 +1,10 @@
 package com.example.todo.dto;
 
 import com.example.todo.enums.Priority;
-import jakarta.validation.constraints.FutureOrPresent;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.experimental.Accessors;
 
 import java.io.Serializable;
 import java.time.LocalDateTime;
@@ -14,12 +13,16 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 public class UpdateTodoRequest implements Serializable {
-
-    @Size(min = 3, max = 120, message = "Text should be between 3 and 120 characters.")
     private String text;
-
     private Priority priority;
-
-    @FutureOrPresent(message = "Due date must be either today or in the future.")
     private LocalDateTime dueDate;
+
+    @Accessors(fluent = true)
+    private boolean updateDueDate;
+
+    public UpdateTodoRequest(String text, Priority priority, LocalDateTime dueDate) {
+        this.text = text;
+        this.priority = priority;
+        this.dueDate = dueDate;
+    }
 }

--- a/src/main/java/com/example/todo/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/todo/exception/GlobalExceptionHandler.java
@@ -52,6 +52,17 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(apiErrorResponse);
     }
 
+    @ExceptionHandler(InvalidUpdateTodoRequestException.class)
+    public ResponseEntity<ApiErrorResponse> handleInvalidUpdateTodoRequestException(InvalidUpdateTodoRequestException ex) {
+        List<FieldErrorResponse> errorDetails = ex.getErrors();
+
+        ApiErrorResponse apiErrorResponse = new ApiErrorResponse(
+                400, "Validation failed for one or more fields.", LocalDateTime.now(), errorDetails
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(apiErrorResponse);
+    }
+
     // Query string parameter conversion failure
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ApiErrorResponse> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException ex) {

--- a/src/main/java/com/example/todo/exception/InvalidUpdateTodoRequestException.java
+++ b/src/main/java/com/example/todo/exception/InvalidUpdateTodoRequestException.java
@@ -1,0 +1,16 @@
+package com.example.todo.exception;
+
+import com.example.todo.dto.FieldErrorResponse;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class InvalidUpdateTodoRequestException extends RuntimeException {
+    private final List<FieldErrorResponse> errors;
+
+    public InvalidUpdateTodoRequestException(List<FieldErrorResponse> errors) {
+        super("Validation failed for update todo request.");
+        this.errors = errors;
+    }
+}

--- a/src/main/java/com/example/todo/mapper/TodoMapper.java
+++ b/src/main/java/com/example/todo/mapper/TodoMapper.java
@@ -45,7 +45,7 @@ public class TodoMapper {
             todo.setPriority(updateTodoRequest.getPriority());
         }
 
-        if (updateTodoRequest.getDueDate() != null) {
+        if (updateTodoRequest.updateDueDate()) {
             todo.setDueDate(updateTodoRequest.getDueDate());
         }
     }

--- a/src/main/java/com/example/todo/util/UpdateTodoRequestValidator.java
+++ b/src/main/java/com/example/todo/util/UpdateTodoRequestValidator.java
@@ -1,0 +1,53 @@
+package com.example.todo.util;
+
+import com.example.todo.dto.FieldErrorResponse;
+import com.example.todo.enums.Priority;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class UpdateTodoRequestValidator {
+    public static List<FieldErrorResponse> validate(Map<String, Object> requestBody) {
+        List<FieldErrorResponse> errors = new ArrayList<>();
+
+        if (requestBody.containsKey("text")) {
+            Object text = requestBody.get("text");
+
+            if (!(text instanceof String textValue) || textValue.isEmpty()) {
+                errors.add(new FieldErrorResponse("text", "Text must be a non-empty string.", text));
+            } else if (textValue.length() < 3 || textValue.length() > 120) {
+                errors.add(new FieldErrorResponse("text", "Text must be between 3 and 120 characters.", textValue));
+            }
+        }
+
+        if (requestBody.containsKey("priority")) {
+            Object priority = requestBody.get("priority");
+
+            if (!(priority instanceof String priorityValue)) {
+                errors.add(new FieldErrorResponse("priority", "Invalid value for priority. It must be one of: LOW, MEDIUM, HIGH.", priority));
+            } else {
+                try {
+                    Priority.valueOf(priorityValue.toUpperCase());
+                } catch (IllegalArgumentException e) {
+                    errors.add(new FieldErrorResponse("priority", "Invalid value for priority. It must be one of: LOW, MEDIUM, HIGH.", priorityValue));
+                }
+            }
+        }
+
+        if (requestBody.containsKey("dueDate")) {
+            Object dueDate = requestBody.get("dueDate");
+
+            if (dueDate != null) {
+                if (!(dueDate instanceof LocalDateTime dueDateValue)) {
+                    errors.add(new FieldErrorResponse("dueDate", "Due date must be a valid date.", dueDate));
+                } else if (dueDateValue.isBefore(LocalDateTime.now())) {
+                    errors.add(new FieldErrorResponse("dueDate", "Due date must be either today or in the future.", dueDateValue));
+                }
+            }
+        }
+
+        return errors;
+    }
+}

--- a/src/main/java/com/example/todo/util/UpdateTodoRequestValidator.java
+++ b/src/main/java/com/example/todo/util/UpdateTodoRequestValidator.java
@@ -4,6 +4,7 @@ import com.example.todo.dto.FieldErrorResponse;
 import com.example.todo.enums.Priority;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -40,10 +41,18 @@ public class UpdateTodoRequestValidator {
             Object dueDate = requestBody.get("dueDate");
 
             if (dueDate != null) {
-                if (!(dueDate instanceof LocalDateTime dueDateValue)) {
-                    errors.add(new FieldErrorResponse("dueDate", "Due date must be a valid date.", dueDate));
-                } else if (dueDateValue.isBefore(LocalDateTime.now())) {
-                    errors.add(new FieldErrorResponse("dueDate", "Due date must be either today or in the future.", dueDateValue));
+                if (!(dueDate instanceof String dueDateString)) {
+                    errors.add(new FieldErrorResponse("dueDate", "Invalid date format. Due date must be a valid LocalDateTime.", dueDate));
+                } else {
+                    try {
+                        LocalDateTime dueDateValue = LocalDateTime.parse(dueDateString);
+
+                        if (dueDateValue.isBefore(LocalDateTime.now())) {
+                            errors.add(new FieldErrorResponse("dueDate", "Due date must be either today or in the future.", dueDateValue));
+                        }
+                    } catch (DateTimeParseException e) {
+                        errors.add(new FieldErrorResponse("dueDate", "Invalid date format. Due date must be a valid LocalDateTime.", dueDate));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Update the update endpoint to receive a map of key-value pairs as the request body, implement input validation, and send appropriate error message responses. With this approach, updates to the dueDate field can either leave the current value unchanged, set it to null, or update it to a new date.